### PR TITLE
fix invalid headers error, reject amqp message

### DIFF
--- a/packages/backend/transport/TransportInvalidHeadersError.ts
+++ b/packages/backend/transport/TransportInvalidHeadersError.ts
@@ -1,0 +1,21 @@
+import { ExtendedError } from '@ts-core/common/error';
+
+export class TransportInvalidHeadersError extends ExtendedError<void> {
+    // --------------------------------------------------------------------------
+    //
+    //  Constants
+    //
+    // --------------------------------------------------------------------------
+
+    public static ERROR_CODE = 5100;
+
+    // --------------------------------------------------------------------------
+    //
+    //  Constructor
+    //
+    // --------------------------------------------------------------------------
+
+    constructor(message: string) {
+        super(message, TransportInvalidHeadersError.ERROR_CODE);
+    }
+}


### PR DESCRIPTION
When Invalid Header error trowed, now reject amqp message and log full message content instead process.exit(1)